### PR TITLE
Lexical rules: block comments

### DIFF
--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -22,7 +22,7 @@ rule token = parse
   | digit+ as lxm     { LITINT (int_of_string lxm) }
   | "true"            { LITBOOL true }
   | "false"           { LITBOOL false }
-  | "{#"              { comment_begin := fst (Location.curr_loc lexbuf); read_comment 0 lexbuf }
+  | "{#"              { comment_begin := L.lexeme_start_p lexbuf; read_comment 0 lexbuf }
   | eof               { EOF }
   | _                 { illegal_character (Location.curr_loc lexbuf) (L.lexeme_char lexbuf 0) }
 
@@ -34,5 +34,5 @@ and read_comment nested_count = parse
               read_comment (nested_count-1) lexbuf
           }
   | '\n'  { L.new_line lexbuf; read_comment nested_count lexbuf }
-  | eof   { Error.error (!comment_begin, snd (Location.curr_loc lexbuf)) "unterminated comment" }
+  | eof   { Error.error (!comment_begin, L.lexeme_end_p lexbuf) "unterminated comment" }
   | _     { read_comment nested_count lexbuf }


### PR DESCRIPTION
Ainda precisa corrigir a posição inicial de quando dá o erro `unterminated comment`. A solução que eu pensei é passar essa  posição como parâmero para o `read_comment`, mas não sei é o melhor. Tem alguma forma de fazer o `read_comment` não incrementar a posição ao ler o buffer?