### PR TITLE
Lexical Rules: Operadores

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
    - [x] integer literals (Romildo - PR)
    - [ ] real literals
    - [ ] string literals
-   - [ ] operators
+   - [x] operators (Koda - PR #26)
    - [ ] punctuation symbols
    - [ ] keyworkds
    
@@ -20,6 +20,6 @@
    - [ ] integer literals
    - [ ] real literals
    - [ ] string literals
-   - [ ] operators
+   - [x] operators (Koda - PR #26)
    - [ ] punctuation symbols
    - [ ] keyworkds

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -20,5 +20,20 @@ rule token = parse
   | digit+ as lxm     { LITINT (int_of_string lxm) }
   | "true"            { LITBOOL true }
   | "false"           { LITBOOL false }
+  | "+"               { PLUS }
+  | "-"               { MINUS }
+  | "*"               { TIMES }
+  | "/"               { DIV }
+  | "%"               { MOD }
+  | "^"               { POW }
+  | "="               { EQ }
+  | "<>"              { NE }
+  | ">"               { GT }
+  | ">="              { GE }
+  | "<"               { LT }
+  | "<="              { LE }
+  | "&&"              { AND }
+  | "||"              { OR }
+  | ":="              { ASSIGN }
   | eof               { EOF }
   | _                 { illegal_character (Location.curr_loc lexbuf) (L.lexeme_char lexbuf 0) }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -7,5 +7,19 @@
 %token                 EOF
 %token <int>           LITINT
 %token <bool>          LITBOOL
-
+%token                 PLUS
+%token                 MINUS
+%token                 TIMES
+%token                 DIV
+%token                 MOD
+%token                 POW
+%token                 EQ
+%token                 NE
+%token                 GT
+%token                 GE
+%token                 LT 
+%token                 LE
+%token                 AND
+%token                 OR
+%token                 ASSIGN
 %%

--- a/src/lib/test_lexer.ml
+++ b/src/lib/test_lexer.ml
@@ -144,7 +144,7 @@ let%expect_test _ =
     :1.5-1.5 Parser.EOF |}];
 
   (* operators *)
-  scan_string "+ - * / % ^ = <> > >= < <= & | :=";
+  scan_string "+ - * / % ^ = <> > >= < <= && || :=";
   [%expect{|
     :1.0-1.1 Parser.PLUS
     :1.2-1.3 Parser.MINUS

--- a/src/lib/test_lexer.ml
+++ b/src/lib/test_lexer.ml
@@ -158,10 +158,10 @@ let%expect_test _ =
     :1.19-1.21 Parser.GE
     :1.22-1.23 Parser.LT
     :1.24-1.26 Parser.LE
-    :1.27-1.28 Parser.AND
-    :1.29-1.30 Parser.OR
-    :1.31-1.33 Parser.ASSIGN
-    :1.33-1.33 Parser.EOF |}];
+    :1.27-1.29 Parser.AND
+    :1.30-1.32 Parser.OR
+    :1.33-1.35 Parser.ASSIGN
+    :1.35-1.35 Parser.EOF |}];
 
   (* punctuation *)
   scan_string "( ) , ; :";


### PR DESCRIPTION
Fiz a implementação dos operadores. 
No arquivo de descrição da linguagem os operadores && e || estavam descritos dessa forma (com dois de cada). 
Alterei o arquivo de teste (constava apenas & e |) para que ficasse em conformidade com a documentação proposta.
Parece passar nos testes! 