### PR TITLE
travis: add some missing opam packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 before_install:
   - opam init -y --compiler=4.10.1
   - eval `opam config env`
-  - opam install -y dune ocamlfind menhir
+  - opam install -y dune ocamlfind menhir camomile ppx_import ppx_deriving ppx_expect
   - sudo chmod +x compile.sh
 
 matrix:


### PR DESCRIPTION
Travis is failing to build the project because some needed opam packages are not installed.