### PR TITLE
Anotate ast with its location in source code

### DIFF
--- a/src/driver/driver.ml
+++ b/src/driver/driver.ml
@@ -27,7 +27,7 @@ let main () =
   try
     (* scan lexbuf *)
     let ast = Parser.program Lexer.token lexbuf in
-    Format.printf "%s\n" (Absyn.show_exp ast)
+    Format.printf "%s\n" (Absyn.show_lexp ast)
   with
   | Error.Error (loc, msg) ->
      Format.printf "%a error: %s\n" Location.pp_location loc msg;

--- a/src/lib/absyn.ml
+++ b/src/lib/absyn.ml
@@ -4,6 +4,9 @@ type exp =
   | BoolExp   of bool
   | IntExp    of int
   | RealExp   of float
-  | WhileExp  of (exp * exp)
+  | WhileExp  of (lexp * lexp)
   | BreakExp
+  [@@deriving show]
+
+and lexp = exp Location.loc  (* exp anotated with a location *)
   [@@deriving show]

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -41,7 +41,7 @@
 %token                 VAR
 %token                 WHILE
 
-%start <Absyn.exp> program
+%start <Absyn.lexp> program
 
 %%
 
@@ -49,8 +49,8 @@ program:
 | e=exp EOF            {e}
 
 exp:
-| x=LITBOOL            {BoolExp x}
-| x=LITINT             {IntExp x}
-| x=LITREAL            {RealExp x}
-| WHILE t=exp DO b=exp {WhileExp (t, b)}
-| BREAK                {BreakExp}
+| x=LITBOOL            {$loc, BoolExp x}
+| x=LITINT             {$loc, IntExp x}
+| x=LITREAL            {$loc, RealExp x}
+| WHILE t=exp DO b=exp {$loc, WhileExp (t, b)}
+| BREAK                {$loc, BreakExp}


### PR DESCRIPTION
Carry location information along with abstract syntax trees.
