### PR TITLE
ATIVIDADE 3 - 23/09

### DIFF
--- a/src/lib/absyn.ml
+++ b/src/lib/absyn.ml
@@ -50,6 +50,13 @@ and var =
 
 and dec =
   | VarDec of vardec typed
+  | FunDec of fundec typed
+  [@@deriving show]
+
+and fundec = symbol * paramdef list * symbol * lexp
+  [@@deriving show]
+
+and paramdef = symbol * symbol
   [@@deriving show]
 
 and vardec = Symbol.symbol * Symbol.symbol option * lexp

--- a/src/lib/absyntree.ml
+++ b/src/lib/absyntree.ml
@@ -27,6 +27,10 @@ let tree_of_option conversion_function opt =
   | None   -> Tree.empty
   | Some v -> conversion_function v
 
+let tree_of_param (s, s') = mktr "ParamDef" [tree_of_symbol s; tree_of_symbol s']
+
+let tree_of_paramlist p = mktr "ParamList" (List.map tree_of_param p)
+
 (* Convert a binary operator to a string *)
 let stringfy_op op =
   match op with
@@ -86,11 +90,18 @@ and tree_of_var var =
 and tree_of_dec dec =
   match dec with
   | VarDec vardec -> tree_of_typed tree_of_vardec vardec
+  | FunDec fundec -> tree_of_typed tree_of_fundec fundec
 
 and tree_of_vardec (v, t, i) =
   mktr "VarDec" [ tree_of_symbol v;
                   tree_of_option tree_of_symbol t;
                   tree_of_lexp i ]
+
+and tree_of_fundec (n, p, t, e) =
+  mktr "FunDec" [ tree_of_symbol n;
+                  tree_of_paramlist p;
+                  tree_of_symbol t;
+                  tree_of_lexp e ]
 
 (* Convert an anotated expression to a generic tree *)
 and tree_of_lexp (_, x) = tree_of_exp x

--- a/src/lib/lexer.mll
+++ b/src/lib/lexer.mll
@@ -72,6 +72,7 @@ rule token = parse
   | "then"            { THEN }
   | "var"             { VAR }
   | "while"           { WHILE }
+  | "function"        { FUNCTION }
   | id as lxm         { ID (Symbol.symbol lxm) }
   | '"'               { stringRule lexbuf.L.lex_start_p "" lexbuf }
   | eof               { EOF }

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -44,6 +44,7 @@
 %token                 VAR
 %token                 WHILE
 %token                 UMINUS
+%token                 FUNCTION
 
 %right                 OR
 %right                 AND
@@ -58,52 +59,58 @@
 %%
 
 program:
-| e=exp EOF                                    {e}
+| e=exp EOF                                            {e}
 
 exp:
-| x=LITBOOL                                    {$loc % BoolExp x}
-| x=LITINT                                     {$loc % IntExp x}
-| x=LITREAL                                    {$loc % RealExp x}
-| x=LITSTRING                                  {$loc % StringExp x}
-| MINUS e=exp             %prec UMINUS         {$loc % NegativeExp e}
-| l=exp PLUS r=exp                             {$loc % BinaryExp (l, Plus, r)}
-| l=exp MINUS r=exp                            {$loc % BinaryExp (l, Minus, r)}
-| l=exp TIMES r=exp                            {$loc % BinaryExp (l, Times, r)}
-| l=exp DIV r=exp                              {$loc % BinaryExp (l, Div, r)}
-| l=exp MOD r=exp                              {$loc % BinaryExp (l, Mod, r)}
-| l=exp POW r=exp                              {$loc % BinaryExp (l, Power, r)}
-| l=exp EQ r=exp                               {$loc % BinaryExp (l, Equal, r)}
-| l=exp NE r=exp                               {$loc % BinaryExp (l, NotEqual, r)}
-| l=exp GT r=exp                               {$loc % BinaryExp (l, GreaterThan, r)}
-| l=exp GE r=exp                               {$loc % BinaryExp (l, GreaterEqual, r)}
-| l=exp LT r=exp                               {$loc % BinaryExp (l, LowerThan, r)}
-| l=exp LE r=exp                               {$loc % BinaryExp (l, LowerEqual, r)}
-| l=exp AND r=exp                              {$loc % BinaryExp (l, And, r)}
-| l=exp OR r=exp                               {$loc % BinaryExp (l, Or, r)}
-| WHILE t=exp DO b=exp                         {$loc % WhileExp (t, b)}
-| BREAK                                        {$loc % BreakExp}
-| IF t=exp THEN b=exp v=option(ELSE c=exp {c}) {$loc % IfExp (t,b,v)}
-| f=ID LPAREN p=exp_list RPAREN                {$loc % CallExp (f, p)}
-| LPAREN es=exp_seq RPAREN                     {$loc % SeqExp es}
-| x=var                                        {$loc % VarExp x}
-| LET d=list(dec) IN e=exp                     {$loc % LetExp (d, e)}
-| x=var ASSIGN e=exp                           {$loc % AssignExp (x, e)}
+| x=LITBOOL                                            {$loc % BoolExp x}
+| x=LITINT                                             {$loc % IntExp x}
+| x=LITREAL                                            {$loc % RealExp x}
+| x=LITSTRING                                          {$loc % StringExp x}
+| MINUS e=exp             %prec UMINUS                 {$loc % NegativeExp e}
+| l=exp PLUS r=exp                                     {$loc % BinaryExp (l, Plus, r)}
+| l=exp MINUS r=exp                                    {$loc % BinaryExp (l, Minus, r)}
+| l=exp TIMES r=exp                                    {$loc % BinaryExp (l, Times, r)}
+| l=exp DIV r=exp                                      {$loc % BinaryExp (l, Div, r)}
+| l=exp MOD r=exp                                      {$loc % BinaryExp (l, Mod, r)}
+| l=exp POW r=exp                                      {$loc % BinaryExp (l, Power, r)}
+| l=exp EQ r=exp                                       {$loc % BinaryExp (l, Equal, r)}
+| l=exp NE r=exp                                       {$loc % BinaryExp (l, NotEqual, r)}
+| l=exp GT r=exp                                       {$loc % BinaryExp (l, GreaterThan, r)}
+| l=exp GE r=exp                                       {$loc % BinaryExp (l, GreaterEqual, r)}
+| l=exp LT r=exp                                       {$loc % BinaryExp (l, LowerThan, r)}
+| l=exp LE r=exp                                       {$loc % BinaryExp (l, LowerEqual, r)}
+| l=exp AND r=exp                                      {$loc % BinaryExp (l, And, r)}
+| l=exp OR r=exp                                       {$loc % BinaryExp (l, Or, r)}
+| WHILE t=exp DO b=exp                                 {$loc % WhileExp (t, b)}
+| BREAK                                                {$loc % BreakExp}
+| IF t=exp THEN b=exp v=option(ELSE c=exp {c})         {$loc % IfExp (t,b,v)}
+| f=ID LPAREN p=exp_list RPAREN                        {$loc % CallExp (f, p)}
+| LPAREN es=exp_seq RPAREN                             {$loc % ExpSeq es}
+| x=var                                                {$loc % VarExp x}
+| LET d=list(dec) IN e=exp                             {$loc % LetExp (d, e)}
 
 (* semicolon separated sequence of expressions *)
 exp_seq:
-| es=separated_list(SEMI, exp)                 {es}
+| es=separated_list(SEMI, exp)                                          {es}
 
 (* function call arguments *)
 exp_list:
-| opt=separated_list(COMMA, exp)               {opt}
+| opt=separated_list(COMMA, exp)                                        {opt}
 
 (* variables *)
 var:
-| x=ID                                         {$loc, SimpleVar x}
+| x=ID                                                                  {$loc, SimpleVar x}
 
 (* declarations *)
 dec:
-| VAR x=ID t=optional_type EQ e=exp            {$loc, VarDec (dummyt (x, t, e))}
+| VAR x=ID t=optional_type EQ e=exp                                     {$loc, VarDec (dummyt (x, t, e))}
+| FUNCTION n=ID LPAREN p=param_list RPAREN COLON t=ID EQ e=exp          {$loc, FunDec (dummyt (n, p, t, e))}
 
 optional_type:
-| ot=option(COLON t=ID {t})                    {ot}
+| ot=option(COLON t=ID {t})                                             {ot}
+
+param_list:
+| t=separated_list(COMMA, param)                                        {t}
+
+param:
+| n=ID COLON t=ID                                                       {n, t}

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -85,7 +85,7 @@ exp:
 | BREAK                                                {$loc % BreakExp}
 | IF t=exp THEN b=exp v=option(ELSE c=exp {c})         {$loc % IfExp (t,b,v)}
 | f=ID LPAREN p=exp_list RPAREN                        {$loc % CallExp (f, p)}
-| LPAREN es=exp_seq RPAREN                             {$loc % ExpSeq es}
+| LPAREN es=exp_seq RPAREN                             {$loc % SeqExp es}
 | x=var                                                {$loc % VarExp x}
 | LET d=list(dec) IN e=exp                             {$loc % LetExp (d, e)}
 

--- a/src/lib/semantic.ml
+++ b/src/lib/semantic.ml
@@ -142,8 +142,8 @@ and check_dec_fun env pos ((name, params_list, type_ret, body), tref) =
  
   let tbody = check_exp envbody body in                                                 (* Checking if the body's return type matches the function's type *)
     match tbody with
-    | rt       -> ignore(set tref rt); env'
-    | _        -> type_mismatch pos rt tbody
+    | rtp when rtp = rt -> ignore(set tref rt); env'
+    | _                 -> type_mismatch pos rt tbody
 
 (* Matching parameters' types passed into function call to its required types, as well as the number of parameters *)
 

--- a/src/lib/semantic.ml
+++ b/src/lib/semantic.ml
@@ -58,16 +58,14 @@ let set reference value =
 
 let rec get_formals lparams acc env pos =
   match lparams with
-  | (n, t)::tail -> get_formals tail (acc @ [tylook env.tenv t pos]) env pos
-  | [(n, t)]     -> acc @ [tylook env.tenv t pos]
+  | (_, t)::tail -> get_formals tail (acc @ [tylook env.tenv t pos]) env pos
   | []           -> acc
 
 (* Returns the variables' names in the function parameters list *)
 
 let rec get_formals_names lparams acc =
   match lparams with
-  | (n, t)::tail -> get_formals_names tail (acc @ [S.name n])
-  | [(n, t)]     -> acc @ [S.name n]
+  | (n, _)::tail -> get_formals_names tail (acc @ [S.name n])
   | []           -> acc
 
 (* Checks if item is in the list *)
@@ -89,7 +87,6 @@ let rec add_funvar2env lparam env pos =
    | (n, t)::tail -> let venv' = S.enter n (VarEntry (tylook env.tenv t pos)) env.venv in
                      let env' = {env with venv = venv'} in
                      add_funvar2env tail env' pos
-   | [(n, t)]     -> let venv' = S.enter n (VarEntry (tylook env.tenv t pos)) env.venv in {env with venv = venv'}
    | []           -> env
 
 (* Returns a new environment with the current function *)


### PR DESCRIPTION
Esse _pull request_ apresenta **apenas** a atividade para o dia 21/09, `porém, os testes apresentados a seguir foram feitos com as mudanças dos meus pull requests anteriores`, já que foi necessário incluir as expressões das outras atividades na análise semântica.

O código-fonte utilizado para estes testes pode ser acessado [nesta _branch_](https://github.com/whitesimian/bcc328.2020.3/tree/teste_atividade_21_09).

Seguem os testes, na ordem:

![1](https://user-images.githubusercontent.com/38870713/93663570-bdabdb00-fa47-11ea-8d42-65e0368bd9f4.PNG)

![2](https://user-images.githubusercontent.com/38870713/93663571-bf759e80-fa47-11ea-9d04-23a0a5fd2ac4.PNG)

![3](https://user-images.githubusercontent.com/38870713/93663572-c0a6cb80-fa47-11ea-9850-57e7368b2ab2.PNG)

![4](https://user-images.githubusercontent.com/38870713/93663574-c1d7f880-fa47-11ea-8ce7-4390193cadaf.PNG)

![5](https://user-images.githubusercontent.com/38870713/93663576-c3092580-fa47-11ea-93d2-545eb41e66ec.PNG)

![6](https://user-images.githubusercontent.com/38870713/93663577-c4d2e900-fa47-11ea-818e-fb8927618c3a.PNG)

![7](https://user-images.githubusercontent.com/38870713/93663578-c6041600-fa47-11ea-9549-04fe9335838f.PNG)

![8](https://user-images.githubusercontent.com/38870713/93663579-c7354300-fa47-11ea-933d-90f45acc86ce.PNG)

![new3](https://user-images.githubusercontent.com/38870713/93666123-4af82b00-fa5a-11ea-9256-817814c18efd.PNG)

![10](https://user-images.githubusercontent.com/38870713/93663584-c9979d00-fa47-11ea-8d79-a91d2283a9bf.PNG)

![ifthenelse](https://user-images.githubusercontent.com/38870713/93666684-ec817b80-fa5e-11ea-8f80-eb50c44b831d.PNG)

![12](https://user-images.githubusercontent.com/38870713/93663587-cbf9f700-fa47-11ea-9313-88836c8f5ba9.PNG)

==================================================================================

Testes extras:

![extra1](https://user-images.githubusercontent.com/38870713/93693787-30b65f80-fae3-11ea-9348-d7363af7f173.PNG)

![extra2](https://user-images.githubusercontent.com/38870713/93693791-33b15000-fae3-11ea-986b-435e5d100401.PNG)

======== # ========

![extra 3](https://user-images.githubusercontent.com/38870713/93693797-5479a580-fae3-11ea-8d95-bf031f45a96e.PNG)

======== # ========

Após o último exemplo do Rodrigo, percebi a falta de recursividade mútua na minha análise de expressões. Todos os testes acima foram refeitos e são ainda válidos.
Achei que fez sentido alterar o `check_let_exp` para incluir a recursividade.
Segue mais um exemplo:

![alem1](https://user-images.githubusercontent.com/38870713/94116511-eb1ecd00-fe29-11ea-90f9-155fec0e041b.PNG)

![alem2](https://user-images.githubusercontent.com/38870713/94116527-ef4aea80-fe29-11ea-99fe-b09349bf4f95.PNG)

Este exemplo **não** deveria dar certo pois não me atentei ao fato de que para haver recursividade mútua na nossa linguagem, as funções têm que estar declaradas em sequência.