### PR TITLE
Rename constructor for sequence expression ast

### DIFF
--- a/src/lib/absyn.ml
+++ b/src/lib/absyn.ml
@@ -20,7 +20,7 @@ and exp_basic =
   | IfExp         of (lexp * lexp * lexp option)
   | WhileExp      of (lexp * lexp)
   | BreakExp
-  | ExpSeq        of lexp list
+  | SeqExp        of lexp list
   | CallExp       of symbol * lexp list
   | VarExp        of lvar
   | LetExp        of ldec list * lexp

--- a/src/lib/absyntree.ml
+++ b/src/lib/absyntree.ml
@@ -72,7 +72,7 @@ and tree_of_exp_basic exp =
   | IfExp (t,b,c)             -> mktr "IfExp" [tree_of_lexp t; tree_of_lexp b; tree_of_option tree_of_lexp c]
   | WhileExp (t, b)           -> mktr "WhileExp" [tree_of_lexp t; tree_of_lexp b]
   | BreakExp                  -> mktr "BreakExp" []
-  | ExpSeq seq                -> mktr "ExpSeq" (List.map tree_of_lexp seq)
+  | SeqExp seq                -> mktr "SeqExp" (List.map tree_of_lexp seq)
   | CallExp (f, xs)           -> mktr "CallExp" [mktr (name f) []; mktr "Args" (List.map tree_of_lexp xs)]
   | VarExp x                  -> mktr "VarExp" [tree_of_lvar x]
   | LetExp (d, e)             -> mktr "LetExp" [mktr "Decs" (List.map tree_of_ldec d); tree_of_lexp e]

--- a/src/lib/parser.mly
+++ b/src/lib/parser.mly
@@ -84,7 +84,7 @@ exp:
 | BREAK                                        {$loc % BreakExp}
 | IF t=exp THEN b=exp v=option(ELSE c=exp {c}) {$loc % IfExp (t,b,v)}
 | f=ID LPAREN p=exp_list RPAREN                {$loc % CallExp (f, p)}
-| LPAREN es=exp_seq RPAREN                     {$loc % ExpSeq es}
+| LPAREN es=exp_seq RPAREN                     {$loc % SeqExp es}
 | x=var                                        {$loc % VarExp x}
 | LET d=list(dec) IN e=exp                     {$loc % LetExp (d, e)}
 


### PR DESCRIPTION
It was not consistent with other constructor names.